### PR TITLE
Refactor parameters

### DIFF
--- a/src/main/java/com/ustermetrics/ecos4j/Model.java
+++ b/src/main/java/com/ustermetrics/ecos4j/Model.java
@@ -9,6 +9,7 @@ import lombok.val;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -133,21 +134,32 @@ public class Model implements AutoCloseable {
 
     /**
      * Sets the <a href="https://github.com/embotech/ecos">ECOS</a> solver options.
+     * <p>
+     * For {@code null} option values solver defaults are applied.
      *
      * @param parameters the parameter object for the solver options.
      */
     public void setParameters(@NonNull Parameters parameters) {
         checkState(stage != Stage.NEW, "Model must not be in stage new");
 
-        settings.feastol(stgsSeg, parameters.getFeasTol());
-        settings.abstol(stgsSeg, parameters.getAbsTol());
-        settings.reltol(stgsSeg, parameters.getRelTol());
-        settings.feastol_inacc(stgsSeg, parameters.getFeasTolInacc());
-        settings.abstol_inacc(stgsSeg, parameters.getAbsTolInacc());
-        settings.reltol_inacc(stgsSeg, parameters.getRelTolInacc());
-        settings.maxit(stgsSeg, parameters.getMaxIt());
-        settings.nitref(stgsSeg, parameters.getNItRef());
-        settings.verbose(stgsSeg, parameters.isVerbose() ? 1 : 0);
+        Optional.ofNullable(parameters.feasTol())
+                .ifPresent(feasTol -> settings.feastol(stgsSeg, feasTol));
+        Optional.ofNullable(parameters.absTol())
+                .ifPresent(absTol -> settings.abstol(stgsSeg, absTol));
+        Optional.ofNullable(parameters.relTol())
+                .ifPresent(relTol -> settings.reltol(stgsSeg, relTol));
+        Optional.ofNullable(parameters.feasTolInacc())
+                .ifPresent(feasTolInacc -> settings.feastol_inacc(stgsSeg, feasTolInacc));
+        Optional.ofNullable(parameters.absTolInacc())
+                .ifPresent(absTolInacc -> settings.abstol_inacc(stgsSeg, absTolInacc));
+        Optional.ofNullable(parameters.relTolInacc())
+                .ifPresent(relTolInacc -> settings.reltol_inacc(stgsSeg, relTolInacc));
+        Optional.ofNullable(parameters.maxIt())
+                .ifPresent(maxIt -> settings.maxit(stgsSeg, maxIt));
+        Optional.ofNullable(parameters.nItRef())
+                .ifPresent(nItRef -> settings.nitref(stgsSeg, nItRef));
+        Optional.ofNullable(parameters.verbose())
+                .ifPresent(verbose -> settings.verbose(stgsSeg, verbose ? 1 : 0));
     }
 
     /**

--- a/src/main/java/com/ustermetrics/ecos4j/Parameters.java
+++ b/src/main/java/com/ustermetrics/ecos4j/Parameters.java
@@ -1,73 +1,40 @@
 package com.ustermetrics.ecos4j;
 
 import lombok.Builder;
-import lombok.Getter;
 import lombok.val;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.ustermetrics.ecos4j.bindings.ecos_h.*;
 
 /**
  * A parameter object for <a href="https://github.com/embotech/ecos">ECOS</a> solver options.
+ * <p>
+ * For {@code null} option values {@link Model#setParameters(Parameters parameters)} applies solver defaults.
+ *
+ * @param feasTol      the primal/dual infeasibility tolerance.
+ * @param absTol       the absolute tolerance on the duality gap.
+ * @param relTol       the relative tolerance on the duality gap.
+ * @param feasTolInacc the inaccurate solution feasibility tolerance.
+ * @param absTolInacc  the inaccurate solution absolute tolerance.
+ * @param relTolInacc  the inaccurate solution relative tolerance.
+ * @param nItRef       the number of iterative refinement steps.
+ * @param maxIt        the maximum number of iterations.
+ * @param verbose      the verbose mode.
+ * @see <a href="https://github.com/embotech/ecos">ECOS</a>
  */
-@Getter
 @Builder
-public class Parameters {
+public record Parameters(Double feasTol, Double absTol, Double relTol, Double feasTolInacc, Double absTolInacc,
+                         Double relTolInacc, Integer nItRef, Integer maxIt, Boolean verbose) {
 
-    @Builder.Default
-    private double feasTol = FEASTOL();
-    @Builder.Default
-    private double absTol = ABSTOL();
-    @Builder.Default
-    private double relTol = RELTOL();
-    @Builder.Default
-    private double feasTolInacc = FTOL_INACC();
-    @Builder.Default
-    private double absTolInacc = ATOL_INACC();
-    @Builder.Default
-    private double relTolInacc = RTOL_INACC();
-    @Builder.Default
-    private int nItRef = NITREF();
-    @Builder.Default
-    private int maxIt = MAXIT();
-    @Builder.Default
-    private boolean verbose = VERBOSE() == 1;
-
-    /**
-     * Setting the solver options.
-     *
-     * @param feasTol      the primal/dual infeasibility tolerance.
-     * @param absTol       the absolute tolerance on the duality gap.
-     * @param relTol       the relative tolerance on the duality gap.
-     * @param feasTolInacc the inaccurate solution feasibility tolerance.
-     * @param absTolInacc  the inaccurate solution absolute tolerance.
-     * @param relTolInacc  the inaccurate solution relative tolerance.
-     * @param nItRef       the number of iterative refinement steps.
-     * @param maxIt        the maximum number of iterations.
-     * @param verbose      the verbose mode.
-     * @see <a href="https://github.com/embotech/ecos">ECOS</a>
-     */
-    public Parameters(double feasTol, double absTol, double relTol, double feasTolInacc, double absTolInacc,
-                      double relTolInacc, int nItRef, int maxIt, boolean verbose) {
-        val errMsg = "%s must be positive";
-        checkArgument(feasTol > 0., errMsg, "feasTol");
-        checkArgument(absTol > 0., errMsg, "absTol");
-        checkArgument(relTol > 0., errMsg, "relTol");
-        checkArgument(feasTolInacc > 0., errMsg, "feasTolInacc");
-        checkArgument(absTolInacc > 0., errMsg, "absTolInacc");
-        checkArgument(relTolInacc > 0., errMsg, "relTolInacc");
-        checkArgument(nItRef > 0, errMsg, "nItRef");
-        checkArgument(maxIt > 0, errMsg, "maxIt");
-
-        this.feasTol = feasTol;
-        this.absTol = absTol;
-        this.relTol = relTol;
-        this.feasTolInacc = feasTolInacc;
-        this.absTolInacc = absTolInacc;
-        this.relTolInacc = relTolInacc;
-        this.maxIt = maxIt;
-        this.nItRef = nItRef;
-        this.verbose = verbose;
+    public Parameters {
+        val errMsg = "%s must be null or positive";
+        checkArgument(feasTol == null || feasTol > 0., errMsg, "feasTol");
+        checkArgument(absTol == null || absTol > 0., errMsg, "absTol");
+        checkArgument(relTol == null || relTol > 0., errMsg, "relTol");
+        checkArgument(feasTolInacc == null || feasTolInacc > 0., errMsg, "feasTolInacc");
+        checkArgument(absTolInacc == null || absTolInacc > 0., errMsg, "absTolInacc");
+        checkArgument(relTolInacc == null || relTolInacc > 0., errMsg, "relTolInacc");
+        checkArgument(nItRef == null || nItRef > 0, errMsg, "nItRef");
+        checkArgument(maxIt == null || maxIt > 0, errMsg, "maxIt");
     }
 
 }

--- a/src/test/java/com/ustermetrics/ecos4j/ParametersTest.java
+++ b/src/test/java/com/ustermetrics/ecos4j/ParametersTest.java
@@ -16,21 +16,21 @@ class ParametersTest {
                 .feasTolInacc(1.)
                 .absTolInacc(1.)
                 .relTolInacc(1.)
-                .nItRef(1)
+                .nItRef(null)
                 .maxIt(1)
                 .verbose(true)
                 .build();
 
         val tol = 1e-8;
-        assertEquals(1., parameters.getFeasTol(), tol);
-        assertEquals(1., parameters.getAbsTol(), tol);
-        assertEquals(1., parameters.getRelTol(), tol);
-        assertEquals(1., parameters.getFeasTolInacc(), tol);
-        assertEquals(1., parameters.getAbsTolInacc(), tol);
-        assertEquals(1., parameters.getRelTolInacc(), tol);
-        assertEquals(1, parameters.getNItRef());
-        assertEquals(1, parameters.getMaxIt());
-        assertTrue(parameters.isVerbose());
+        assertEquals(1., parameters.feasTol(), tol);
+        assertEquals(1., parameters.absTol(), tol);
+        assertEquals(1., parameters.relTol(), tol);
+        assertEquals(1., parameters.feasTolInacc(), tol);
+        assertEquals(1., parameters.absTolInacc(), tol);
+        assertEquals(1., parameters.relTolInacc(), tol);
+        assertNull(parameters.nItRef());
+        assertEquals(1, parameters.maxIt());
+        assertTrue(parameters.verbose());
     }
 
     @Test
@@ -39,7 +39,7 @@ class ParametersTest {
                 .feasTol(-1.)
                 .build());
 
-        assertEquals("feasTol must be positive", exception.getMessage());
+        assertEquals("feasTol must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -48,7 +48,7 @@ class ParametersTest {
                 .absTol(-1.)
                 .build());
 
-        assertEquals("absTol must be positive", exception.getMessage());
+        assertEquals("absTol must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -57,7 +57,7 @@ class ParametersTest {
                 .relTol(-1.)
                 .build());
 
-        assertEquals("relTol must be positive", exception.getMessage());
+        assertEquals("relTol must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -66,7 +66,7 @@ class ParametersTest {
                 .feasTolInacc(-1.)
                 .build());
 
-        assertEquals("feasTolInacc must be positive", exception.getMessage());
+        assertEquals("feasTolInacc must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -75,7 +75,7 @@ class ParametersTest {
                 .absTolInacc(-1.)
                 .build());
 
-        assertEquals("absTolInacc must be positive", exception.getMessage());
+        assertEquals("absTolInacc must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -84,7 +84,7 @@ class ParametersTest {
                 .relTolInacc(-1.)
                 .build());
 
-        assertEquals("relTolInacc must be positive", exception.getMessage());
+        assertEquals("relTolInacc must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -93,7 +93,7 @@ class ParametersTest {
                 .nItRef(-1)
                 .build());
 
-        assertEquals("nItRef must be positive", exception.getMessage());
+        assertEquals("nItRef must be null or positive", exception.getMessage());
     }
 
     @Test
@@ -102,7 +102,7 @@ class ParametersTest {
                 .maxIt(-1)
                 .build());
 
-        assertEquals("maxIt must be positive", exception.getMessage());
+        assertEquals("maxIt must be null or positive", exception.getMessage());
     }
 
 }


### PR DESCRIPTION
- Use record
- Do not use default values from ECOS in parameters. Instead if a value is null, apply defaults values
- Fix test